### PR TITLE
Re-label from @ahmetkasap to @dds

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,20 @@
+Copyright (c) 2025 Ahmet Kasap
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A migration tool for Elasticsearch/OpenSearch. This package helps you manage you
 ## 🚀 Installation
 
 ```bash
-npm install @ahmetkasap/elasticsearch-migration
+npm install @direct-democracy-solutions/elasticsearch-migration
 ```
 
 ---
@@ -98,7 +98,7 @@ MIGRATIONS_PATH=./migrations
 
 ```typescript
 import { Client } from "@opensearch-project/opensearch";
-import type { IMigration } from "@ahmetkasap/elasticsearch-migration";
+import type { IMigration } from "@direct-democracy-solutions/elasticsearch-migration";
 
 const migration: IMigration = {
   name: "create_users_index",
@@ -136,8 +136,8 @@ export default migration;
 ## 🧑‍💻 Programmatic Usage
 
 ```typescript
-import { MigrationService } from "@ahmetkasap/elasticsearch-migration";
-import type { IMigrationConfig } from "@ahmetkasap/elasticsearch-migration";
+import { MigrationService } from "@direct-democracy-solutions/elasticsearch-migration";
+import type { IMigrationConfig } from "@direct-democracy-solutions/elasticsearch-migration";
 
 const config: IMigrationConfig = {
   node: "http://localhost:9200",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@ahmetkasap/elasticsearch-migration",
+  "name": "@direct-democracy-solutions/elasticsearch-migration",
   "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@ahmetkasap/elasticsearch-migration",
+      "name": "@direct-democracy-solutions/elasticsearch-migration",
       "version": "1.0.1",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@ahmetkasap/elasticsearch-migration",
+  "name": "@direct-democracy-solutions/elasticsearch-migration",
   "version": "1.0.1",
   "description": "Elasticsearch/OpenSearch migration tool",
   "main": "dist/index.js",
@@ -32,12 +32,12 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ahmetkasap/elasticsearch-migration.git"
+    "url": "git+https://github.com/direct-democracy-solutions/elasticsearch-migration.git"
   },
   "bugs": {
-    "url": "https://github.com/ahmetkasap/elasticsearch-migration/issues"
+    "url": "https://github.com/direct-democracy-solutions/elasticsearch-migration/issues"
   },
-  "homepage": "https://github.com/ahmetkasap/elasticsearch-migration#readme",
+  "homepage": "https://github.com/direct-democracy-solutions/elasticsearch-migration#readme",
   "dependencies": {
     "@ahmetkasap/elasticsearch-migration": "^1.0.0",
     "@opensearch-project/opensearch": "^2.4.0",

--- a/src/cli/create.ts
+++ b/src/cli/create.ts
@@ -29,7 +29,7 @@ export async function createMigration(
 
     // Migration template
     const migrationTemplate = `import { Client } from "@opensearch-project/opensearch";
-import type { IMigration } from "elastic-migrate";
+import type { IMigration } from '@direct-democracy-solutions/elasticsearch-migration';
 
 const migration: IMigration = {
 	name: "${migrationName}",


### PR DESCRIPTION
Since Ahmet has not engaged with our pull request, we will be forking this package.

- Rename from @ahmetkasap/elasticsearch-migration to @direct-democracy-solutions/elasticsearch-migration
- Update contact URLs (but not author field of course)
- Add LICENSE.txt with copyright attribution to Ahmet
- Update migration template and example migration to import the new package name

This will be published as version 1.0.1 and will have exact parity with 1.0.1 in the original package, except as noted above. We will develop from there.