### PR TITLE
Add 'forget' subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- New command `es-migrate forget`, an advanced command that can help
+  repair a corrupted migration index. `forget` will remove an applied
+  migration from the index without running its rollback script.
+
 ## [1.1.2] - 2025-10-15
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ npm start
 npm run migrate -- create <name>   # Create new migration
 npm run migrate -- up              # Run pending migrations
 npm run migrate -- down            # Rollback last migration
+npm run migrate -- forget          # Forget last migration, skip rollback
 npm run migrate -- status          # Check migration status
 npm run migrate -- list-indices    # List all indices
 npm run migrate -- alias-info      # Show alias information

--- a/migrations/1751567840547_test_timestamp_colliding_migration.ts
+++ b/migrations/1751567840547_test_timestamp_colliding_migration.ts
@@ -1,0 +1,20 @@
+import type { IMigration } from "..";
+
+const migration: IMigration = {
+  name: "test_timestamp_colliding_migration",
+  timestamp: 1751567840547,
+
+  async up(): Promise<void> {
+    console.log(
+      "Migration test_timestamp_colliding_migration executed successfully",
+    );
+  },
+
+  async down(): Promise<void> {
+    console.log(
+      "Migration test_timestamp_colliding_migration rolled back successfully",
+    );
+  },
+};
+
+export default migration;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -152,4 +152,26 @@ program
     }
   });
 
+program
+  .command("forget")
+  .summary("Forget an applied migration, skip rollback")
+  .description(
+    "Deletes a migration from the list of those already applied, without " +
+      "applying the rollback script. Can be used to repair the migration " +
+      "index if it is corrupt.\n\nDo not use this unless you know what you are doing.",
+  )
+  .argument(
+    "[migration]",
+    "Name or timestamp of the migration to forget (defaults to the last migration).",
+  )
+  .action(async (name?: string) => {
+    try {
+      const { forgetMigration } = await import("./cli/forget.js");
+      await forgetMigration(name);
+    } catch (error) {
+      console.error("Error forgetting migration:", error);
+      process.exit(1);
+    }
+  });
+
 program.parse();

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -1,0 +1,11 @@
+// Load environment variables
+import { IMigrationConfig } from "../types/migration.interface";
+import "dotenv/config";
+
+// Configuration from environment variables
+export const config: IMigrationConfig = {
+  node: process.env.ELASTIC_SEARCH_NODE ?? "http://localhost:9200",
+  username: process.env.ELASTIC_SEARCH_USERNAME,
+  password: process.env.ELASTIC_SEARCH_PASSWORD,
+  migrationsPath: process.env.MIGRATIONS_PATH ?? "./migrations",
+};

--- a/src/cli/forget.ts
+++ b/src/cli/forget.ts
@@ -1,0 +1,24 @@
+import { MigrationService } from "../services/migration.service.js";
+import { fileURLToPath } from "url";
+import { config } from "./config.js";
+
+export async function forgetMigration(name?: string | number) {
+  try {
+    const migrationService = new MigrationService(config);
+    await migrationService.forgetMigration(name);
+  } catch (error) {
+    console.error("Error forgetting migration:", error);
+    process.exit(1);
+  }
+}
+
+// Standalone execution
+function main() {
+  const nameOrTimestamp = process.argv[2];
+  const timestamp = Number.parseInt(nameOrTimestamp ?? NaN, 10);
+  return forgetMigration(Number.isNaN(timestamp) ? nameOrTimestamp : timestamp);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  await main();
+}

--- a/test/elastic.test.ts
+++ b/test/elastic.test.ts
@@ -1,11 +1,14 @@
+import { jest } from "@jest/globals";
 import { Client } from "@opensearch-project/opensearch";
 import { MigrationService } from "../src";
 import type { IMigrationConfig } from "../src";
-import path from "path";
+import * as path from "path";
+import { matches } from "../src/services/migration.service";
 
 describe("E2E Tests", () => {
   let client: Client;
   let migrationService: MigrationService;
+  let oldLog: typeof console.log;
 
   const migrationIndex = ".test-migrations";
 
@@ -30,6 +33,9 @@ describe("E2E Tests", () => {
     });
 
     migrationService = new MigrationService(testConfig);
+
+    oldLog = console.log;
+    console.log = jest.fn();
   });
 
   afterAll(async () => {
@@ -42,6 +48,8 @@ describe("E2E Tests", () => {
         index: migrationIndex,
       });
     }
+
+    console.log = oldLog;
   });
 
   describe("Elasticsearch Connection", () => {
@@ -88,6 +96,170 @@ describe("E2E Tests", () => {
     test("should get applied migrations (empty)", async () => {
       const appliedMigrations = await migrationService.getAppliedMigrations();
       expect(appliedMigrations).toEqual([]);
+    });
+
+    describe("forget", () => {
+      it("should remove the most recent migration without calling the down function if no argument", async () => {
+        const migrations = await migrationService.getPendingMigrations();
+        expect(migrations.length).toBeGreaterThanOrEqual(1);
+        const migrationToForget = migrations[0];
+        const rollback = migrationToForget.down;
+        migrationToForget.down = jest
+          .fn()
+          .mockReturnValue(Promise.resolve()) as () => Promise<void>;
+        try {
+          await migrationService.applyMigration(migrationToForget);
+          try {
+            await migrationService.forgetMigration();
+            expect(await migrationService.getAppliedMigrations()).not.toContain(
+              migrationToForget,
+            );
+            expect(await migrationService.getPendingMigrations()).toContain(
+              migrationToForget,
+            );
+            expect(migrationToForget.down).not.toHaveBeenCalled();
+          } finally {
+            const pending = await migrationService.getPendingMigrations();
+            if (pending.some((m) => matches(migrationToForget, m))) {
+              await migrationService.downMigration();
+            } else if (typeof rollback === "function") {
+              await rollback(client);
+            }
+          }
+        } finally {
+          migrationToForget.down = rollback;
+        }
+      });
+
+      it(
+        "should forget a single migration by unique name",
+        testForgetBy("name"),
+      );
+
+      it(
+        "should refuse to forget a migration by non-unique name",
+        testDontForgetAmbiguous("name", "test_migration"),
+      );
+
+      it(
+        "should forget a single migration by unique timestamp",
+        testForgetBy("timestamp"),
+      );
+
+      it(
+        "should refuse to forget a migration by non-unique timestamp",
+        testDontForgetAmbiguous("timestamp", 1751567840547),
+      );
+
+      function testForgetBy(k: "name" | "timestamp") {
+        return async () => {
+          const migrations = await migrationService.getPendingMigrations();
+          expect(migrations.length).toBeGreaterThanOrEqual(2);
+          const migrationToForget = migrations[0];
+          const migrationNotToForget = migrations.find(
+            (m) => m[k] !== migrationToForget[k],
+          )!;
+          expect(migrationNotToForget).toBeDefined();
+          const rollback = migrationToForget.down;
+          migrationToForget.down = jest
+            .fn()
+            .mockReturnValue(Promise.resolve()) as () => Promise<void>;
+          try {
+            await migrationService.applyMigration(migrationToForget);
+            await migrationService.applyMigration(migrationNotToForget);
+            try {
+              // Verify unique search term
+              expect(
+                (await migrationService.getAppliedMigrations()).filter(
+                  (m) => m[k] === migrationToForget[k],
+                ).length,
+              ).toBe(1);
+              // Forget the migration
+              await migrationService.forgetMigration(migrationToForget[k]);
+              expect(
+                await migrationService.getAppliedMigrations(),
+              ).not.toContain(migrationToForget);
+              expect(await migrationService.getPendingMigrations()).toContain(
+                migrationToForget,
+              );
+              expect(migrationToForget.down).not.toHaveBeenCalled();
+            } finally {
+              const pending = await migrationService.getPendingMigrations();
+              if (pending.some((p) => matches(p, migrationNotToForget))) {
+                await migrationService.downMigration();
+              }
+              if (pending.some((p) => matches(p, migrationToForget))) {
+                await migrationService.downMigration();
+              } else if (typeof rollback === "function") {
+                await rollback(client);
+              }
+            }
+          } finally {
+            migrationToForget.down = rollback;
+          }
+        };
+      }
+
+      function testDontForgetAmbiguous(
+        k: "name" | "timestamp",
+        v: string | number,
+      ) {
+        return async () => {
+          const migrations = (
+            await migrationService.getPendingMigrations()
+          ).filter((m) => m[k] === v);
+          expect(migrations.length).toBeGreaterThanOrEqual(2);
+          const rollback = migrations.map((m) => {
+            const r = m.down;
+            m.down = jest
+              .fn()
+              .mockReturnValue(Promise.resolve()) as () => Promise<void>;
+            return r;
+          });
+          try {
+            await Promise.all(
+              migrations.map((m) => migrationService.applyMigration(m)),
+            );
+            // Verify non-unique name
+            expect(
+              (await migrationService.getAppliedMigrations()).filter(
+                (m) => m[k],
+              ).length,
+            ).toBeGreaterThanOrEqual(2);
+
+            // Try to forget the migration
+            await migrationService.forgetMigration(v);
+
+            // Make sure it was refused
+            const [applied, pending] = await Promise.all([
+              migrationService.getAppliedMigrations(),
+              migrationService.getPendingMigrations(),
+            ]);
+            await Promise.all(
+              migrations.map((m) => {
+                expect(applied.some((a) => matches(a, m))).toBe(true);
+                expect(pending.every((p) => !matches(m, p))).toBe(true);
+                expect(m.down).not.toHaveBeenCalled();
+              }),
+            );
+          } finally {
+            const pending = await migrationService.getAppliedMigrations();
+            while (migrations.length > 0) {
+              const m = migrations.pop()!;
+              const rb = rollback[migrations.length]!;
+              try {
+                if (pending.some((p) => matches(p, m))) {
+                  await migrationService.downMigration();
+                } else if (rb !== undefined) {
+                  await rb(client);
+                }
+              } finally {
+                m.down = rb;
+              }
+            }
+          }
+        };
+      }
     });
   });
 });


### PR DESCRIPTION
`es-migrate forget` is an advanced command that can help repair a corrupted migration index. `forget` will remove an applied migration from the index without running its rollback script.

For instance, if you were developing locally and applied a migration that has since been deleted, `es-migrate down` will fail because there is no local rollback script. Instead of manually deleting the migration from Elasticsearch, you could run `es-migrate forget` and the migration will be gone from the index.