### PR TITLE
Increase max-concurrency for tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,6 @@ jobs:
 
   test:
     strategy:
-      max-parallel: 1
       matrix:
         node-version: [20.9.0, 20, 22, 24]
 


### PR DESCRIPTION
A concurrency limit was needed in the project this CI code came from,
because I was hitting an external rate-limited resource. Not the case
here.
