### PR TITLE
Tighten up CI pipeline

### DIFF
--- a/.github/actions/set-up-ci/action.yml
+++ b/.github/actions/set-up-ci/action.yml
@@ -3,7 +3,27 @@ description: "Set up Node and install project dependencies"
 inputs:
   node-version:
     description: Node version to set up
-    required: false # Defaults to "node-version-file"
+    # This shouldn't be required; but in practice node-version must be
+    # set on Linux runners; otherwise updating NPM will fail.
+    #
+    # See https://github.com/actions/setup-node/issues/1409. When fixed,
+    # this can be set back to false and then "node-version" will default
+    # to whatever is specified "node-version-file".
+    required: true
+  npm-version:
+    description: NPM version to use for the package
+    # Unfortunately, our devEngines configuration specifies an older
+    # version, even though 11.5.1 is required to support
+    # [oidc-based publishing](https://docs.npmjs.com/trusted-publishers).
+    # This is because the setup-node action breaks if
+    # devEngines.packageManager.version is set higher than the NPM
+    # version it ships with.
+    #
+    # See [setup-node #1410](https://github.com/actions/setup-node/issues/1410).
+    #
+    # When this bug is fixed, update setup-node and increase
+    # packageManager.version to 11.5.1 minimum.
+    default: 11.5.1
 
 runs:
   using: "composite"
@@ -14,5 +34,8 @@ runs:
         check-latest: true
         cache: "npm"
         cache-dependency-path: "package-lock.json"
+    - name: install npm ${{ inputs.npm-version }}
+      run: npm install -g npm@${{ inputs.npm-version }}
+      shell: "bash"
     - run: npm ci
       shell: "bash"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,12 @@ on:
   pull_request:
     branches:
       - master
+
   workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
 
 jobs:
   lint:
@@ -15,45 +20,55 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/set-up-ci
+        with:
+          node-version: lts/*
       - run: npx prettier --check .
       - run: npm run lint -- --max-warnings 0
 
   test:
     strategy:
       matrix:
-        node-version: [20.9.0, 20, 22, 24]
+        # 18.14.0 is the earliest we can successfully run with Jest
+        node-version: [18.14.0, 18, 20, 22, 24, latest]
 
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/set-up-ci
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: lts/*
       - run: docker compose up --wait
       - run: npm run build
       - run: cp ci.env .env
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: "npm"
+          cache-dependency-path: "package-lock.json"
       - run: npm test
-        if: ${{ matrix.node-version != '20.9.0' }}
-      - run: npm run test:node20
-        if: ${{ matrix.node-version == '20.9.0' }}
+        if: ${{ matrix.node-version != '18.14.0' && matrix.node-version != '18' }}
+      - name: test
+        run: node --experimental-vm-modules node_modules/jest/bin/jest.js
+        shell: "bash"
+        if: ${{matrix.node-version == '18.14.0' || matrix.node-version == '18' }}
 
   build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/set-up-ci
+        with:
+          node-version: lts/*
       - run: npm run build
 
   release-dry-run:
     runs-on: ubuntu-latest
-    env:
-      NPM_TOKEN: ${{ secrets.NPM_PUBLISH_KEY }}
     steps:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
       - uses: ./.github/actions/set-up-ci
-      - name: Configure NPM auth
-        run: npm config set //registry.npmjs.org/:_authToken $NPM_TOKEN
-      - run: npm publish --dry-run
-      - run: npm run release -- --dry-run
+        with:
+          node-version: lts/*
+      - run: npm --version
+      - run: npm run release -- --ci --no-git.requireCleanWorkingDir --dry-run

--- a/.release-it.json
+++ b/.release-it.json
@@ -10,7 +10,8 @@
     }
   },
   "npm": {
-    "publish": true
+    "publish": true,
+    "skipChecks": true
   },
   "hooks": {
     "after:bump": "npm run build"

--- a/package.json
+++ b/package.json
@@ -15,9 +15,7 @@
     "start": "node dist/index.js",
     "migrate": "tsx src/cli.ts",
     "test": "node --experimental-vm-modules --disable-warning=ExperimentalWarning node_modules/jest/bin/jest.js",
-    "test:node20": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
     "prepublishOnly": "npm run build",
-    "dry-release": "npm run release -- --ci --no-npm.publish --no-git.requireCleanWorkingDir --dry-run",
     "release": "release-it",
     "pre-commit": "npm ci && eslint --max-warnings=0 && prettier --check . && npm run build && test"
   },
@@ -71,5 +69,15 @@
   ],
   "engines": {
     "node": ">=18.0.0"
+  },
+  "devEngines": {
+    "runtime": {
+      "name": "node",
+      "version": ">= 20.17.0"
+    },
+    "packageManager": {
+      "name": "npm",
+      "version": "^10.9.3 || ^11.5.1"
+    }
   }
 }


### PR DESCRIPTION
The dry-release workflow now uses the new OIDC-based authentication flow to authenticate with NPM, removing the need for access tokens. This is to support NPM's move away from tokens in light of recent supply chain attacks.

To support the new flow, the CI environment had to be upgraded to NPM 11.5.1, which requires Node 20.17 or later. However, we support Node all back to 18.0.0, so the CI flow has been tweaked to run most of the pipeline in latest LTS and install a different Node version just before running the tests.

Note that although we support back to 18.0.0, our test suite runs only on 18.14.0 or later. We won't be making a lot of changes till our next major release, which will drop Node 18; so hopefully the coverage gap won't cause big problems.

Finally, the 'npm publish --dry-run' command has been removed from CI. Since it was running without release-it, the version number would always conflict with the version on NPM and cause a failure.

"devEngines" has been set in package.json to help keep track of all this.