### PR TITLE
Set Node version to work around setup-node #1409

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -14,5 +14,5 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/set-up-ci
         with:
-          node-version: 'lts/*'
+          node-version: "lts/*"
       - run: npm audit


### PR DESCRIPTION
node-version must be explicitly set in the setup-node workflow input to ensure Node is installed in a non-root directory, so NPM can be updated without a permission error.

See https://github.com/actions/setup-node/issues/1409.